### PR TITLE
Add ENTRYPOINT support to Agentfile and Agentfile.yml

### DIFF
--- a/src/agentman/agentfile_schema.py
+++ b/src/agentman/agentfile_schema.py
@@ -151,6 +151,11 @@ AGENTFILE_YAML_SCHEMA: Dict[str, Any] = {
             "description": "Default command to run in the container",
             "default": ["python", "agent.py"],
         },
+        "entrypoint": {
+            "type": "array", 
+            "items": {"type": "string"},
+            "description": "Entrypoint command for the container"
+        },
         "secrets": {
             "type": "array",
             "description": "List of secrets the agent needs",

--- a/src/agentman/yaml_parser.py
+++ b/src/agentman/yaml_parser.py
@@ -81,6 +81,9 @@ class AgentfileYamlParser:
         # Parse command
         self._parse_command(data.get('command', []))
 
+        # Parse entrypoint
+        self._parse_entrypoint(data.get('entrypoint', []))
+
         # Parse secrets if they exist
         self._parse_secrets(data.get('secrets', []))
 
@@ -319,6 +322,14 @@ class AgentfileYamlParser:
                 self.config.cmd = command_config
             else:
                 raise ValueError("Command must be a list")
+
+    def _parse_entrypoint(self, entrypoint_config: List[str]):
+        """Parse entrypoint configuration."""
+        if entrypoint_config:
+            if isinstance(entrypoint_config, list):
+                self.config.entrypoint = entrypoint_config
+            else:
+                raise ValueError("Entrypoint must be a list")
 
     def _parse_secrets(self, secrets_config: List[Union[str, Dict[str, Any]]]):
         """Parse secrets configuration."""


### PR DESCRIPTION
This PR implements ENTRYPOINT support for both Agentfile and Agentfile.yml formats, following the same pattern as existing CMD support.

## Changes
- Add entrypoint field to AgentfileConfig
- Add ENTRYPOINT parsing for both array and simple formats
- Add YAML schema and parser support
- Update Agent Builder to generate ENTRYPOINT instructions
- Fix JSON array formatting for CMD/ENTRYPOINT
- Add comprehensive test coverage

## Usage
**Agentfile:** `ENTRYPOINT ["python", "agent.py"]`
**YAML:** `entrypoint: ["python", "agent.py"]`

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)